### PR TITLE
refactor: Add logic to handle the response from FCM/APNs

### DIFF
--- a/agora-chat/push_tester.go
+++ b/agora-chat/push_tester.go
@@ -5,6 +5,7 @@ package agora_chat
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ycj3/agora-chat-cli/http"
 )
@@ -30,8 +31,27 @@ type FcmData struct {
 	FcmError *fcmErrorResponse `json:"error,omitempty"`
 }
 
+type PushNotification struct {
+	Payload    string    `json:"payload"`
+	Topic      string    `json:"topic"`
+	Expiration time.Time `json:"expiration"`
+	Priority   string    `json:"priority"`
+	Token      string    `json:"token"`
+}
+
+type apnsResponse struct {
+	TokenInvalidationTimestamp interface{}      `json:"tokenInvalidationTimestamp"`
+	ApnsUniqueId               string           `json:"apnsUniqueId"`
+	Accepted                   bool             `json:"accepted"`
+	ApnsId                     string           `json:"apnsId"`
+	RejectionReason            interface{}      `json:"rejectionReason"`
+	PushNotification           PushNotification `json:"pushNotification"`
+	StatusCode                 int              `json:"statusCode"`
+}
+
 type PushResultData struct {
 	FcmData
+	apnsResponse
 }
 
 type PushResult struct {

--- a/agora-chat/push_tester.go
+++ b/agora-chat/push_tester.go
@@ -13,12 +13,34 @@ type PushManager struct {
 	client *client
 }
 
-type PushResult struct {
-	PushStatus string                 `json:"pushStatus"`
-	Data       map[string]interface{} `json:"data,omitempty"` // contains the response from the provider you are useing (e.g. FCM or APNs)
-	Desc       string                 `json:"desc,omitempty"`
-	StatusCode int                    `json:"statusCode,omitempty"`
+type fcmErrorResponse struct {
+	Code    int    `json:"code"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Details []struct {
+		ErrorCode string `json:"errorCode"`
+	}
 }
+type fcmResponse struct {
+	Name string `json:"name,omitempty"`
+}
+
+type FcmData struct {
+	fcmResponse
+	FcmError *fcmErrorResponse `json:"error,omitempty"`
+}
+
+type PushResultData struct {
+	FcmData
+}
+
+type PushResult struct {
+	PushStatus string         `json:"pushStatus"`
+	Data       PushResultData `json:"data,omitempty"` // contains the response from the provider you are useing (e.g. FCM or APNs)
+	Desc       string         `json:"desc,omitempty"`
+	StatusCode int            `json:"statusCode,omitempty"`
+}
+
 type PushResponseResult struct {
 	Response
 	Data []PushResult `json:"data"`

--- a/agora-chat/push_tester_test.go
+++ b/agora-chat/push_tester_test.go
@@ -54,7 +54,6 @@ var _ = Describe("PushManager", func() {
 					Data: []PushResult{
 						{
 							PushStatus: "Success",
-							Data:       map[string]interface{}{"provider": "FCM"},
 							Desc:       "Push sent successfully",
 							StatusCode: gohttp.StatusOK,
 						},

--- a/cmd/push_tester.go
+++ b/cmd/push_tester.go
@@ -120,6 +120,12 @@ func handlePushTestResponse(res ac.PushResponseResult) error {
 				logger.Info(fmt.Sprintf("%sMessage sent successfully via FCM", dot), map[string]interface{}{
 					"message-id": dataItem.Data.Name,
 				})
+			} else if dataItem.Data.StatusCode == 200 && dataItem.Data.ApnsUniqueId != "" && dataItem.Data.Accepted {
+				logger.Info(fmt.Sprintf("%sMessage sent successfully via APNs", dot), map[string]interface{}{
+					"apnsUniqueId": dataItem.Data.ApnsUniqueId,
+				})
+			} else {
+				return fmt.Errorf("unknow success type for push")
 			}
 		}
 	}
@@ -132,8 +138,16 @@ func handlePushTestResponse(res ac.PushResponseResult) error {
 					"errorCode": dataItem.Data.FcmError.Details[0].ErrorCode,
 					"status":    dataItem.Data.FcmError.Status,
 				})
+			} else if dataItem.Data.StatusCode != 200 && dataItem.Data.ApnsUniqueId == "" && !dataItem.Data.Accepted {
+				logger.Error(fmt.Sprintf("%sFailed to send message via APNs: %s", dot, dataItem.Data.RejectionReason), map[string]interface{}{
+					"statusCode": dataItem.Data.StatusCode,
+					"apnsId":     dataItem.Data.ApnsId,
+					"token":      dataItem.Data.PushNotification.Token,
+				})
 			} else if dataItem.Desc != "" {
 				logger.Error(fmt.Sprintf("%sFailed to send message: %s", dot, dataItem.Desc), nil)
+			} else {
+				return fmt.Errorf("unknow failure type for push")
 			}
 
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,6 @@ func rootCmd() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			logger = log.NewLogger(verbose)
 			if cmdutil.IsAuthCheckEnabled(cmd) {
-				println(cmd.Use)
 				initChatClient()
 			}
 			cfg, err := ac.NewConfig()


### PR DESCRIPTION
Add logic to handle the response from FCM/APNs, ensuring that both success and failure cases are properly managed.
- **Add FCM response handler**
- **format print style**
- **Add logic to handle the response from APNs**
- **fix: fix push tester test error**
